### PR TITLE
[feature] add handling command line error

### DIFF
--- a/Test_Shell/TestShell.cpp
+++ b/Test_Shell/TestShell.cpp
@@ -20,15 +20,25 @@ vector<string> TestShell::splitBySpace(const string& input) {
 int TestShell::handleCommand(string commandLine) {
     vector<string> commandToken = splitBySpace(commandLine);
 
-	if (commandToken[0] == "read") {
-		return read(std::stoi(commandToken[1]));
-	}
-	else if (commandToken[0] == "write") {
-		return write(std::stoi(commandToken[1]), static_cast<unsigned int>(std::stoul(commandToken[2], nullptr, 16)));
-	}
-	else
-		return -1;
+    if (commandToken[0] == "read") {
+		if (commandToken.size() != 2)
+			return -1;
+		if (std::stoi(commandToken[1]) >= 100 || std::stoi(commandToken[1]) < 0)
+			return -1;
+		
+        return read(std::stoi(commandToken[1]));
+    }
+    else if (commandToken[0] == "write") {
+        if (commandToken.size() != 3)
+            return -1;
+		if (std::stoi(commandToken[1]) >= 100 || std::stoi(commandToken[1]) < 0)
+			return -1;
+		if (commandToken[2].length() != 10)
+			return -1;
+        return write(std::stoi(commandToken[1]), static_cast<unsigned int>(std::stoul(commandToken[2], nullptr, 16)));
+    }
 }
+
 int TestShell::write(int lba, uint32_t data)
 {
 	int result = 0; // system("ssd.exe");

--- a/Test_Shell/TestShellTest.cpp
+++ b/Test_Shell/TestShellTest.cpp
@@ -51,6 +51,32 @@ TEST(TS, handleWriteCommand) {
 	EXPECT_EQ(ts.handleCommand("write 3 0xAAAABBBB"), 0);
 }
 
+TEST(TS, handleWrongReadCommandParaNum) {
+	TestShell ts;
+	EXPECT_EQ(ts.handleCommand("read"), -1);
+}
+
+TEST(TS, handleWrongWriteCommandParaNum) {
+	TestShell ts;
+	EXPECT_EQ(ts.handleCommand("write 3 0xAAAABBBB 2"), -1);
+}
+
+TEST(TS, handleWrongReadLBA) {
+	TestShell ts;
+	EXPECT_EQ(ts.handleCommand("read 200"), -1);
+}
+
+TEST(TS, handleWrongWriteLBA) {
+	TestShell ts;
+	EXPECT_EQ(ts.handleCommand("write 300 0xAAAABBBB"), -1);
+}
+
+TEST(TS, handleWrongWriteData) {
+	TestShell ts;
+	EXPECT_EQ(ts.handleCommand("write 55 0xAABBBB"), -1);
+}
+
+
 int main() {
 	::testing::InitGoogleMock();
 	return RUN_ALL_TESTS();


### PR DESCRIPTION
Implement handling wrong command line case.
Also TC is added.

in handling read command,
 check LBA range,
 check number of param. always should be one param. [lba]

in handling write command,
 check LBA range,
 check Data length. always should be two param [lba, data]