### PR TITLE
Refact/ssd

### DIFF
--- a/AClass_SSD/Data.cpp
+++ b/AClass_SSD/Data.cpp
@@ -2,27 +2,22 @@
 #include <fstream>
 #include <sstream>
 
-// 생성자: 파일 이름 저장
 Data::Data(std::string fileName) : DataInterface(fileName) {}
 
-// 파일을 문자열로 로드
 std::string Data::loadFromFile() {
     std::ifstream inFile(fileName);
     if (!inFile.is_open()) {
-        // 파일이 없거나 열 수 없으면 빈 문자열 반환
         return "";
     }
 
     std::ostringstream ss;
-    ss << inFile.rdbuf();  // 전체 파일 읽기
+    ss << inFile.rdbuf();
     return ss.str();
 }
 
-// 문자열 데이터를 파일에 저장
 void Data::saveToFile(std::string data) const {
     std::ofstream outFile(fileName);
     if (!outFile.is_open()) {
-        // 실패해도 예외는 발생하지 않음
         return;
     }
 

--- a/AClass_SSD/DataTest.cpp
+++ b/AClass_SSD/DataTest.cpp
@@ -1,14 +1,14 @@
 #include "Data.h"
 #include "gtest/gtest.h"
 #include <fstream>
-#include <cstdio>  // remove()
+#include <cstdio>
 
 class DataTest : public ::testing::Test {
 protected:
     const std::string testFile = "test_file.txt";
 
     void TearDown() override {
-        std::remove(testFile.c_str());  // 테스트 후 파일 제거
+        std::remove(testFile.c_str());
     }
 
     bool fileExists(const std::string& name) {
@@ -16,15 +16,11 @@ protected:
         return f.good();
     }
 };
-
-// 테스트 1: 파일이 없을 때 loadFromFile은 빈 문자열 반환
 TEST_F(DataTest, LoadFromNonexistentFileReturnsEmptyString) {
     Data d(testFile);
     std::string content = d.loadFromFile();
     EXPECT_EQ(content, "");
 }
-
-// 테스트 2: 저장 후 다시 읽으면 동일한 데이터 반환
 TEST_F(DataTest, SaveAndLoadConsistency) {
     Data d(testFile);
     std::string message = "SSD Emulator Test";
@@ -34,8 +30,6 @@ TEST_F(DataTest, SaveAndLoadConsistency) {
 
     EXPECT_EQ(loaded, message);
 }
-
-// 테스트 3: 덮어쓰기 테스트
 TEST_F(DataTest, OverwriteFileContent) {
     Data d(testFile);
     std::string first = "First Content";
@@ -47,8 +41,6 @@ TEST_F(DataTest, OverwriteFileContent) {
     d.saveToFile(second);
     EXPECT_EQ(d.loadFromFile(), second);
 }
-
-// 테스트 4: saveToFile만 호출해도 파일이 생성되는지 확인
 TEST_F(DataTest, SaveCreatesFileIfNotExists) {
     Data d(testFile);
     EXPECT_FALSE(fileExists(testFile));

--- a/AClass_SSD/SSDController.cpp
+++ b/AClass_SSD/SSDController.cpp
@@ -16,9 +16,10 @@ void SSDController::writeLBA(int lba, uint32_t value) {
 	return;
 }
 
-unsigned int SSDController::readLBA(int lba) {
+uint32_t SSDController::readLBA(int lba) {
 	if (lba < 0 || lba >= LBA_SIZE) throw std::invalid_argument("LBA must be greater than or equal to 0 and less than 100");
 	if (ssdData.empty()) getSsdDataFromFile();
+
 	return ssdData[lba];
 }
 

--- a/AClass_SSD/SSDController.h
+++ b/AClass_SSD/SSDController.h
@@ -9,8 +9,8 @@ class SSDController : public SSDControllerInterface {
 
 public:
 	SSDController(DataInterface* data);
-	void writeLBA(int lba, unsigned int value) override;
-	unsigned int readLBA(int lba) override;
+	void writeLBA(int lba, uint32_t value) override;
+	uint32_t readLBA(int lba) override;
 private:
 	void getSsdDataFromFile();
 	void saveSsdDataToFile();

--- a/AClass_SSD/SSDControllerInterface.h
+++ b/AClass_SSD/SSDControllerInterface.h
@@ -5,10 +5,10 @@
 class SSDControllerInterface {
 public:
 	SSDControllerInterface(DataInterface* data) : data(data) {};
-	virtual void writeLBA(int lba, unsigned int value) = 0;
-	virtual unsigned int readLBA(int lba) = 0;
+	virtual void writeLBA(int lba, uint32_t value) = 0;
+	virtual uint32_t readLBA(int lba) = 0;
 protected:
 	static const int LBA_SIZE = 100;
-	std::vector<unsigned int> ssdData;
+	std::vector<uint32_t> ssdData;
 	DataInterface* data;
 };

--- a/AClass_SSD/SSDControllerTest.cpp
+++ b/AClass_SSD/SSDControllerTest.cpp
@@ -17,9 +17,9 @@ public:
 class SSDDataTest : public Test {
 public:
 	std::string data = "0xffffff10\n0x00000020\n";
-	std::vector<unsigned int> data2Int = { 0xffffff10 ,0x00000020 };
+	std::vector<uint32_t> data2Int = { 0xffffff10 ,0x00000020 };
 	std::string emptyData = "";
-	unsigned int emptyData2Int = 0x00000000;
+	uint32_t emptyData2Int = 0x00000000;
 	DataMock dataMock;
 	SSDController ssd;
 

--- a/AClass_SSD/SSDControllerTest.cpp
+++ b/AClass_SSD/SSDControllerTest.cpp
@@ -14,50 +14,52 @@ public:
 	MOCK_METHOD(std::string, loadFromFile, (), (override));
 	MOCK_METHOD(void, saveToFile, (std::string), (const, override));
 };
-class SSDDataTest : public Test {
+class SSDControllerTestFixture : public Test {
 public:
 	std::string data = "0xffffff10\n0x00000020\n";
 	std::vector<uint32_t> data2Int = { 0xffffff10 ,0x00000020 };
+	
 	std::string emptyData = "";
 	uint32_t emptyData2Int = 0x00000000;
+	
 	DataMock dataMock;
 	SSDController ssd;
 
-	SSDDataTest() : dataMock("test.txt"), ssd(&dataMock) {}
+	SSDControllerTestFixture() : dataMock("test.txt"), ssd(&dataMock) {}
 };
 
-TEST_F(SSDDataTest, initSSDDataAndReadLBA) {
+TEST_F(SSDControllerTestFixture, initSSDDataAndReadLBA) {
 
 	EXPECT_CALL(dataMock, loadFromFile()).WillRepeatedly(Return(data));
 
 	EXPECT_EQ(ssd.readLBA(0), data2Int[0]);
 	EXPECT_EQ(ssd.readLBA(1), data2Int[1]);
 }
-TEST_F(SSDDataTest, ReadLBAWhenDataIsEmpty) {
+TEST_F(SSDControllerTestFixture, ReadLBAWhenDataIsEmpty) {
 
 	EXPECT_CALL(dataMock, loadFromFile()).WillRepeatedly(Return(emptyData));
 	EXPECT_EQ(ssd.readLBA(0), emptyData2Int);
 }
-TEST_F(SSDDataTest, ThrowExceptionWhenReadLBAWithInvalidLBAValue) {
+TEST_F(SSDControllerTestFixture, ThrowExceptionWhenReadLBAWithInvalidLBAValue) {
 
 	EXPECT_CALL(dataMock, loadFromFile()).WillRepeatedly(Return(emptyData));
 	EXPECT_THROW({ ssd.readLBA(102); }, std::invalid_argument);
 }
-TEST_F(SSDDataTest, EmptySSDDataAndWriteLBA) {
+TEST_F(SSDControllerTestFixture, EmptySSDDataAndWriteLBA) {
 
 	EXPECT_CALL(dataMock, loadFromFile()).WillRepeatedly(Return(emptyData));
 	EXPECT_CALL(dataMock, saveToFile(StartsWith("0xffffff10\n"))).Times(1);
 
 	ssd.writeLBA(0, 0xffffff10);
 }
-TEST_F(SSDDataTest, NotEmptySSDDataAndWriteLBA) {
+TEST_F(SSDControllerTestFixture, NotEmptySSDDataAndWriteLBA) {
 
 	EXPECT_CALL(dataMock, loadFromFile()).WillRepeatedly(Return(data));
 	EXPECT_CALL(dataMock, saveToFile(StartsWith("0xffffff10\n0xffffff10\n"))).Times(1);
 
 	ssd.writeLBA(1, 0xffffff10);
 }
-TEST_F(SSDDataTest, ThrowExceptionWhenWriteLBAWithInvalidLBAValue) {
+TEST_F(SSDControllerTestFixture, ThrowExceptionWhenWriteLBAWithInvalidLBAValue) {
 
 	EXPECT_THROW({ ssd.writeLBA(102, 0xffffff10); }, std::invalid_argument);
 }


### PR DESCRIPTION
- 불필요한 주석 삭제
- unsigned int 타입을 uint32_t로 변경하였습니다.
- SSDControllerTest로 이름 변경하였습니다.