### PR TITLE
[bugfix] help 명령어 실행 이후 read log 출력 망가짐 해결

### DIFF
--- a/Test_Shell/TestShellDevice.cpp
+++ b/Test_Shell/TestShellDevice.cpp
@@ -49,7 +49,7 @@ uint32_t TestShellDevice::read(int lba)
 	getline(file, strReadData);  // 한 줄만 읽고 싶을 경우
 	file.close();
 
-	std::cout << "[read] LBA : " << std::setw(2) << std::setfill('0') << lba << " : " << strReadData << std::endl;
+	std::cout << "[read] LBA : " << std::right << std::setw(2) << std::setfill('0') << lba << " : " << strReadData << std::endl;
 
 	return stoi(strReadData, nullptr, 16);
 }


### PR DESCRIPTION
lba 1을 읽으면 [read] LBA : 01 : 값 으로 출력되길 원하나
help 커맨드 동작 이후 [read] LBA : 10 : 값 으로 출력이 됨.
help() 에서 setw40 을 써서 출력을 바꾸게 되고
이것이 이후 read()에 있는 std::left << std::setw(40) 이 적용이 된 상태, 즉 왼쪽 정렬이 되어있는 상태에서 setw(2)가 동작하여 01이 아닌 10이
출력이 되는 이슈가 있어서 read 함수 로그 출력 시 right 정렬하도록 바꿈.