### PR TITLE
[refactor] [REFACTOR] SSD 구조 통합

### DIFF
--- a/AClass_SSD/Command.cpp
+++ b/AClass_SSD/Command.cpp
@@ -3,25 +3,34 @@
 #include <iomanip>
 #include <stdexcept>
 
-Command::Command(std::shared_ptr<SSDControllerInterface> ssdData, std::shared_ptr<FileTextIOInterface> outputFile)
-	: ssd(std::move(ssdData)), outputFile(std::move(outputFile)){}
+Command::Command(std::shared_ptr<SSDControllerInterface> ssdData,
+	std::shared_ptr<FileTextIOInterface> outputFile)
+	: ssd(std::move(ssdData)), outputFile(std::move(outputFile)) {}
 
-void Command::execute(const std::string& cmdType, const int lba, const std::string& valueHex) {
+void Command::execute(const std::string& cmdType, int lba, const std::string& valueHex) {
 	if (cmdType == "W") {
-		if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0x")
-			throw std::invalid_argument("Invalid hex format. Must be '0x' followed by 8 hex digits.");
-
-		uint32_t value = std::stoul(valueHex, nullptr, 16);
-		ssd->writeLBA(lba, value);
+		executeWrite(lba, valueHex);
 	}
 	else if (cmdType == "R") {
-		uint32_t value = ssd->readLBA(lba);
-
-		std::ostringstream oss;
-		oss << "0x" << std::setfill('0') << std::setw(8) << std::hex << std::uppercase << value;
-		outputFile->saveToFile(oss.str());
+		executeRead(lba);
 	}
 	else {
 		throw std::invalid_argument("Invalid command. Use 'R' or 'W'.");
 	}
+}
+
+void Command::executeWrite(int lba, const std::string& valueHex) {
+	if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0x")
+		throw std::invalid_argument("Invalid hex format. Must be '0x' followed by 8 hex digits.");
+
+	uint32_t value = std::stoul(valueHex, nullptr, 16);
+	ssd->writeLBA(lba, value);
+}
+
+void Command::executeRead(int lba) {
+	uint32_t value = ssd->readLBA(lba);
+	std::ostringstream oss;
+	oss << "0x" << std::setfill('0') << std::setw(8)
+		<< std::hex << std::uppercase << value;
+	outputFile->saveToFile(oss.str());
 }

--- a/AClass_SSD/Command.h
+++ b/AClass_SSD/Command.h
@@ -1,12 +1,19 @@
 #pragma once
+#include <memory>
 #include "SSDControllerInterface.h"
+#include "FileTextIOInterface.h"
 
 class Command {
+public:
+	Command(std::shared_ptr<SSDControllerInterface> ssdData,
+		std::shared_ptr<FileTextIOInterface> outputFile);
+
+	void execute(const std::string& cmdType, int lba, const std::string& valueHex = "");
+
 private:
+	void executeWrite(int lba, const std::string& valueHex);
+	void executeRead(int lba);
+
 	std::shared_ptr<SSDControllerInterface> ssd;
 	std::shared_ptr<FileTextIOInterface> outputFile;
-
-public:
-	Command(std::shared_ptr<SSDControllerInterface> ssdData, std::shared_ptr<FileTextIOInterface> outputFile);
-	void execute(const std::string& cmdType, const int lba, const std::string& valueHex = "");
 };

--- a/AClass_SSD/CommandTest.cpp
+++ b/AClass_SSD/CommandTest.cpp
@@ -1,58 +1,59 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <memory>
 #include "Command.h"
 #include "SSDControllerInterface.h"
+#include "FileTextIOInterface.h"
+
+using namespace ::testing;
 
 class MockSSDController : public SSDControllerInterface {
 public:
-    MockSSDController(std::shared_ptr<FileTextIOInterface> data = nullptr) : SSDControllerInterface(std::move(data)) {}
+	MockSSDController(std::shared_ptr<FileTextIOInterface> data = nullptr)
+		: SSDControllerInterface(std::move(data)) {}
 
-    MOCK_METHOD(void, writeLBA, (int lba, unsigned int value), (override));
-    MOCK_METHOD(unsigned int, readLBA, (int lba), (override));
+	MOCK_METHOD(void, writeLBA, (int lba, uint32_t value), (override));
+	MOCK_METHOD(uint32_t, readLBA, (int lba), (override));
 };
 
 class MockDataInterface : public FileTextIOInterface {
 public:
-    MockDataInterface(std::string fileName = "") : FileTextIOInterface(fileName) {}
+	MockDataInterface(std::string fileName = "")
+		: FileTextIOInterface(fileName) {}
 
-    MOCK_METHOD(std::string, loadFromFile, (), (override));
-    MOCK_METHOD(void, saveToFile, (std::string), (const, override));
+	MOCK_METHOD(std::string, loadFromFile, (), (override));
+	MOCK_METHOD(void, saveToFile, (std::string), (const, override));
 };
-
-using namespace ::testing;
 
 class CommandTest : public Test {
 protected:
-    std::shared_ptr<MockSSDController> mockSSD;
-    std::shared_ptr<MockDataInterface> mockOutputFile;
-    std::shared_ptr <Command> command;
+	std::shared_ptr<MockSSDController> mockSSD;
+	std::shared_ptr<MockDataInterface> mockOutputFile;
+	std::unique_ptr<Command> command;
 
-    void SetUp() override {
-        mockSSD = std::make_shared <MockSSDController>();
-        mockOutputFile = std::make_shared <MockDataInterface>("ssd_output.txt");
-        command = std::make_shared <Command>(mockSSD, mockOutputFile);
-    }
-
+	void SetUp() override {
+		auto dummyIO = std::make_shared<MockDataInterface>("test.txt");
+		mockSSD = std::make_shared<MockSSDController>(dummyIO);
+		mockOutputFile = std::make_shared<MockDataInterface>("output.txt");
+		command = std::make_unique<Command>(mockSSD, mockOutputFile);
+	}
 };
+
 TEST_F(CommandTest, ExecuteReadCommand_SavesFormattedOutput) {
-    EXPECT_CALL(*mockSSD, readLBA(5))
-        .Times(1)
-        .WillOnce(Return(0x1234ABCD));
-
-    EXPECT_CALL(*mockOutputFile, saveToFile("0x1234ABCD"))
-        .Times(1);
-
-    command->execute("R", 5);
+	EXPECT_CALL(*mockSSD, readLBA(5)).WillOnce(Return(0x1234ABCD));
+	EXPECT_CALL(*mockOutputFile, saveToFile("0x1234ABCD")).Times(1);
+	command->execute("R", 5);
 }
+
 TEST_F(CommandTest, ExecuteWriteCommand_CallsWriteLBA) {
-    EXPECT_CALL(*mockSSD, writeLBA(7, 0xABCDEF01))
-        .Times(1);
+	EXPECT_CALL(*mockSSD, writeLBA(7, 0xABCDEF01)).Times(1);
+	command->execute("W", 7, "0xABCDEF01");
+}
 
-    command->execute("W", 7, "0xABCDEF01");
-}
 TEST_F(CommandTest, ExecuteInvalidCommand_ThrowsException) {
-    EXPECT_THROW(command->execute("Z", 1), std::invalid_argument);
+	EXPECT_THROW(command->execute("Z", 1), std::invalid_argument);
 }
+
 TEST_F(CommandTest, ExecuteWriteWithBadHexFormat_ThrowsException) {
-    EXPECT_THROW(command->execute("W", 2, "12345678"), std::invalid_argument);
+	EXPECT_THROW(command->execute("W", 2, "12345678"), std::invalid_argument);
 }

--- a/AClass_SSD/FileTextIO.cpp
+++ b/AClass_SSD/FileTextIO.cpp
@@ -5,21 +5,21 @@
 FileTextIO::FileTextIO(std::string fileName) : FileTextIOInterface(fileName) {}
 
 std::string FileTextIO::loadFromFile() {
-    std::ifstream inFile(fileName);
-    if (!inFile.is_open()) {
-        return "";
-    }
+	std::ifstream inFile(fileName);
+	if (!inFile.is_open()) {
+		return "";
+	}
 
-    std::ostringstream ss;
-    ss << inFile.rdbuf();
-    return ss.str();
+	std::ostringstream ss;
+	ss << inFile.rdbuf();
+	return ss.str();
 }
 
 void FileTextIO::saveToFile(const std::string data) const {
-    std::ofstream outFile(fileName);
-    if (!outFile.is_open()) {
-        return;
-    }
+	std::ofstream outFile(fileName);
+	if (!outFile.is_open()) {
+		return;
+	}
 
-    outFile << data;
+	outFile << data;
 }

--- a/AClass_SSD/FileTextIO.h
+++ b/AClass_SSD/FileTextIO.h
@@ -6,8 +6,8 @@
 class FileTextIO : public FileTextIOInterface {
 
 public:
-    FileTextIO(std::string fileName);
+	FileTextIO(std::string fileName);
 
-    std::string loadFromFile() override;
-    void saveToFile(const std::string data) const override;
+	std::string loadFromFile() override;
+	void saveToFile(const std::string data) const override;
 };

--- a/AClass_SSD/FileTextIOInterface.h
+++ b/AClass_SSD/FileTextIOInterface.h
@@ -2,12 +2,12 @@
 #include <string>
 
 class FileTextIOInterface {
- protected:
-  std::string fileName;
+protected:
+	std::string fileName;
 
- public:
-  FileTextIOInterface(std::string fileName) : fileName(fileName) {};
+public:
+	FileTextIOInterface(std::string fileName) : fileName(fileName) {};
 
-  virtual std::string loadFromFile() = 0;
-  virtual void saveToFile(std::string data) const = 0;
+	virtual std::string loadFromFile() = 0;
+	virtual void saveToFile(std::string data) const = 0;
 };

--- a/AClass_SSD/FileTextIOTest.cpp
+++ b/AClass_SSD/FileTextIOTest.cpp
@@ -5,46 +5,46 @@
 
 class FileTextIOTest : public ::testing::Test {
 protected:
-    const std::string testFile = "test_file.txt";
+	const std::string testFile = "test_file.txt";
 
-    void TearDown() override {
-        std::remove(testFile.c_str());
-    }
+	void TearDown() override {
+		std::remove(testFile.c_str());
+	}
 
-    bool fileExists(const std::string& name) {
-        std::ifstream f(name);
-        return f.good();
-    }
+	bool fileExists(const std::string& name) {
+		std::ifstream f(name);
+		return f.good();
+	}
 };
 TEST_F(FileTextIOTest, LoadFromNonexistentFileReturnsEmptyString) {
-    FileTextIO d(testFile);
-    std::string content = d.loadFromFile();
-    EXPECT_EQ(content, "");
+	FileTextIO d(testFile);
+	std::string content = d.loadFromFile();
+	EXPECT_EQ(content, "");
 }
 TEST_F(FileTextIOTest, SaveAndLoadConsistency) {
-    FileTextIO d(testFile);
-    std::string message = "SSD Emulator Test";
+	FileTextIO d(testFile);
+	std::string message = "SSD Emulator Test";
 
-    d.saveToFile(message);
-    std::string loaded = d.loadFromFile();
+	d.saveToFile(message);
+	std::string loaded = d.loadFromFile();
 
-    EXPECT_EQ(loaded, message);
+	EXPECT_EQ(loaded, message);
 }
 TEST_F(FileTextIOTest, OverwriteFileContent) {
-    FileTextIO d(testFile);
-    std::string first = "First Content";
-    std::string second = "Newer Content";
+	FileTextIO d(testFile);
+	std::string first = "First Content";
+	std::string second = "Newer Content";
 
-    d.saveToFile(first);
-    EXPECT_EQ(d.loadFromFile(), first);
+	d.saveToFile(first);
+	EXPECT_EQ(d.loadFromFile(), first);
 
-    d.saveToFile(second);
-    EXPECT_EQ(d.loadFromFile(), second);
+	d.saveToFile(second);
+	EXPECT_EQ(d.loadFromFile(), second);
 }
 TEST_F(FileTextIOTest, SaveCreatesFileIfNotExists) {
-    FileTextIO d(testFile);
-    EXPECT_FALSE(fileExists(testFile));
+	FileTextIO d(testFile);
+	EXPECT_FALSE(fileExists(testFile));
 
-    d.saveToFile("File created via saveToFile");
-    EXPECT_TRUE(fileExists(testFile));
+	d.saveToFile("File created via saveToFile");
+	EXPECT_TRUE(fileExists(testFile));
 }

--- a/AClass_SSD/SSDController.cpp
+++ b/AClass_SSD/SSDController.cpp
@@ -1,24 +1,28 @@
 #include "SSDController.h"
-
 #include <sstream>
 #include <iomanip>
 #include <exception>
 
-SSDController::SSDController(std::shared_ptr<FileTextIOInterface> data) : SSDControllerInterface(std::move(data)) {}
+SSDController::SSDController(std::shared_ptr<FileTextIOInterface> data)
+	: SSDControllerInterface(std::move(data)) {}
 
-void SSDController::writeLBA(int lba, const uint32_t value) {
-	if (lba < 0 || lba >= LBA_SIZE) throw std::invalid_argument("LBA must be greater than or equal to 0 and less than 100");
-	if (ssdData.empty()) getSsdDataFromFile();
+void SSDController::writeLBA(int lba, uint32_t value) {
+	if (lba < 0 || lba >= LBA_SIZE)
+		throw std::invalid_argument("LBA must be between 0 and 99");
+
+	if (ssdData.empty())
+		getSsdDataFromFile();
 
 	ssdData[lba] = value;
-
 	saveSsdDataToFile();
-	return;
 }
 
-uint32_t SSDController::readLBA(const int lba) {
-	if (lba < 0 || lba >= LBA_SIZE) throw std::invalid_argument("LBA must be greater than or equal to 0 and less than 100");
-	if (ssdData.empty()) getSsdDataFromFile();
+uint32_t SSDController::readLBA(int lba) {
+	if (lba < 0 || lba >= LBA_SIZE)
+		throw std::invalid_argument("LBA must be between 0 and 99");
+
+	if (ssdData.empty())
+		getSsdDataFromFile();
 
 	return ssdData[lba];
 }
@@ -28,20 +32,21 @@ void SSDController::getSsdDataFromFile() {
 	std::istringstream iss(rawData);
 	std::string line;
 
-	if (rawData == "") {
+	if (rawData.empty()) {
 		ssdData.resize(LBA_SIZE, 0x00000000);
 		return;
 	}
 
-	while (std::getline(iss, line))
+	while (std::getline(iss, line)) {
 		ssdData.push_back(std::stoul(line, nullptr, 16));
+	}
 }
-void SSDController::saveSsdDataToFile()
-{
-	std::stringstream ss;
 
-	for (auto data : ssdData)
-		ss << "0x" << std::hex << std::setw(8) << std::setfill('0') << std::uppercase << data << '\n';
-
-	data->saveToFile(ss.str());
+void SSDController::saveSsdDataToFile() {
+	std::ostringstream oss;
+	for (const auto& d : ssdData) {
+		oss << "0x" << std::hex << std::setw(8)
+			<< std::setfill('0') << d << '\n';
+	}
+	data->saveToFile(oss.str());
 }

--- a/AClass_SSD/SSDController.h
+++ b/AClass_SSD/SSDController.h
@@ -1,19 +1,15 @@
 #pragma once
-#include <iostream>
-#include <vector>
-
-#include "FileTextIOInterface.h"
+#include <memory>
 #include "SSDControllerInterface.h"
-
 
 class SSDController : public SSDControllerInterface {
 public:
 	SSDController(std::shared_ptr<FileTextIOInterface> data);
-
-	void writeLBA(const int lba, const uint32_t value) override;
-	uint32_t readLBA(const int lba) override;
+	void writeLBA(int lba, uint32_t value) override;
+	uint32_t readLBA(int lba) override;
 
 private:
 	void getSsdDataFromFile();
 	void saveSsdDataToFile();
 };
+

--- a/AClass_SSD/SSDControllerInterface.h
+++ b/AClass_SSD/SSDControllerInterface.h
@@ -5,7 +5,10 @@
 
 class SSDControllerInterface {
 public:
-	SSDControllerInterface(std::shared_ptr<FileTextIOInterface> data) : data(std::move(data)) {}
+	explicit SSDControllerInterface(std::shared_ptr<FileTextIOInterface> data)
+		: data(std::move(data)) {}
+
+	virtual ~SSDControllerInterface() = default;
 
 	virtual void writeLBA(int lba, uint32_t value) = 0;
 	virtual uint32_t readLBA(int lba) = 0;
@@ -13,6 +16,5 @@ public:
 protected:
 	static const int LBA_SIZE = 100;
 	std::vector<uint32_t> ssdData;
-
 	std::shared_ptr<FileTextIOInterface> data;
 };

--- a/AClass_SSD/main.cpp
+++ b/AClass_SSD/main.cpp
@@ -1,24 +1,27 @@
 #include <iostream>
 #include <string>
+#include <memory> 
 #include "Command.h"
 #include "SSDController.h"
 #include "FileTextIO.h"
 
 int main(int argc, char* argv[]) {
+	std::string cmdType = argv[1];
+	int lba = std::stoi(argv[2]);
+	std::string value = (cmdType == "W" && argc == 4) ? argv[3] : "";
 
-    std::string cmdType = argv[1];
-    int lba = std::stoi(argv[2]);
-    std::string value = (cmdType == "W" && argc == 4) ? argv[3] : "";
+	std::shared_ptr<FileTextIOInterface> nandFile = std::make_shared<FileTextIO>("ssd_nand.txt");
+	std::shared_ptr<FileTextIOInterface> outputFile = std::make_shared<FileTextIO>("ssd_output.txt");
+	std::shared_ptr<SSDControllerInterface> ssd = std::make_shared<SSDController>(nandFile);
 
-    std::shared_ptr<SSDController> ssd = std::make_shared<SSDController>(std::make_shared< FileTextIO>("ssd_nand.txt"));
-    std::shared_ptr <FileTextIO> outputFile = std::make_shared<FileTextIO>("ssd_output.txt");
-    Command command(ssd, outputFile);
+	Command command(ssd, outputFile);
 
-    try {
-        command.execute(cmdType, lba, value);
-    }
-    catch (const std::exception& e) {
-        outputFile->saveToFile("ERROR");
-    }
-    return 0;
+	try {
+		command.execute(cmdType, lba, value);
+	}
+	catch (const std::exception& e) {
+		outputFile->saveToFile("ERROR");
+	}
+
+	return 0;
 }


### PR DESCRIPTION
- SSDControllerInterface에 shared_ptr 기반 생성자 추가
- Command 클래스 및 테스트 파일 shared_ptr 일관성 적용
- main 기준으로 rebase 후 충돌 해결 및 정리

구조 변경 (공통 기반 구조 정리)
SSDControllerInterface 생성자 추가 (shared_ptr 기반으로 통일)
Command, SSDController, FileTextIO 생성자 및 내부 멤버를 모두 shared_ptr 기반으로 수정

테스트 코드 통일
MockSSDController, MockDataInterface 생성자에 shared_ptr 추가

테스트 환경 CommandTest.cpp, SSDControllerTest.cpp 일관성 정리

메인 실행부 재정리
main.cpp에서 객체 생성 방식 변경: new → std::make_shared