### PR TITLE
Feature/log manager bug fix

### DIFF
--- a/Test_Shell/Logger.cpp
+++ b/Test_Shell/Logger.cpp
@@ -99,6 +99,7 @@ std::string Logger::formatLogLine(const LogEntry& log) {
 }
 
 std::string Logger::getTimestampedFileName() {
+    std::filesystem::create_directories(logDir);
     std::time_t now = std::time(nullptr);
     std::tm timeInfo;
 
@@ -115,7 +116,7 @@ std::string Logger::getTimestampedFileName() {
         << std::setw(2) << std::setfill('0') << timeInfo.tm_sec << "s"
         << ".log";
 
-    return oss.str();
+    return logDir + "/" + oss.str();
 }
 
 bool Logger::isFileSizeOverTenKb(const std::string& filePath) {

--- a/Test_Shell/Logger.cpp
+++ b/Test_Shell/Logger.cpp
@@ -143,14 +143,23 @@ void Logger::renameFile(const std::string& oldName, const std::string& newName) 
 }
 
 void Logger::compressOldLogFile(std::string lastLogFile) {
-    std::filesystem::path oldLogPath(lastLogFile); // 주어진 파일명을 경로로 변환 
-    std::filesystem::path zipName = oldLogPath;
-    zipName.replace_extension(".zip"); // .txt를 .zip으로 변경
+    try {
+        std::filesystem::path oldLogPath(lastLogFile);
+        std::filesystem::path zipName = oldLogPath;
+        zipName.replace_extension(".zip");
 
-        // 파일 이름 변경 (압축된 파일로 가정하고 이름 변경)
-    std::filesystem::rename(oldLogPath, zipName);
+        if (!std::filesystem::exists(oldLogPath)) {
+            std::cerr << "Old log file does not exist: " << oldLogPath << std::endl;
+            return; // 존재하지 않으면 압축 시도 X
+        }
+
+        std::filesystem::rename(oldLogPath, zipName);
+    }
+    catch (const std::filesystem::filesystem_error& e) {
+        std::cerr << "Failed to compress log file: " << e.what() << std::endl;
+        std::abort(); // 혹은 recover 가능하면 return;
+    }
 }
-
 
 bool Logger::isExistOldLogFile()
 {

--- a/Test_Shell/Logger.h
+++ b/Test_Shell/Logger.h
@@ -34,6 +34,7 @@ private:
     std::string oldLogFilename = "";
     void compressOldLogFile(std::string lastLogFile);
     // 마지막 로그 파일명 // until_260307_17h_12m_11s.log 
+    const std::string logDir = "log"; // 로그 디렉토리 경로
     bool isExistOldLogFile();
     void setOldLogFilename(std::string filename);
     std::string getOldLogFilename(void);


### PR DESCRIPTION
compressOldLogFile() 안에서 파일 존재하지 않아서 abort 발생 --> 파일존재하지않을떄 아무짓도 안하도록 변경