### PR TITLE
[REFACTOR] SSD 명령어 최적화를 위한 CommandBuffer 기능 적용

### DIFF
--- a/AClass_SSD/Command.cpp
+++ b/AClass_SSD/Command.cpp
@@ -2,53 +2,47 @@
 #include <sstream>
 #include <iomanip>
 #include <stdexcept>
-#include <iostream>
+#include <algorithm>
 
-Command::Command(std::shared_ptr<SSDControllerInterface> ssdData,
-	std::shared_ptr<FileTextIOInterface> outputFile)
-	: ssd(std::move(ssdData)), outputFile(std::move(outputFile)) {}
+Command::Command(std::shared_ptr<SSDControllerInterface> ssd,
+    std::shared_ptr<FileTextIOInterface> outputFile,
+    std::shared_ptr<CommandBuffer> buffer)
+    : ssd(ssd), outputFile(outputFile), buffer(buffer) {}
 
-void Command::execute(const std::string& cmdType, int lba, const std::string& valueHex) {
-	if (cmdType == "W" || cmdType == "w") {
-		executeWrite(lba, valueHex);
-	}
-	else if (cmdType == "R" || cmdType == "r") {
-		executeRead(lba);
-	}
-	else if (cmdType == "E" || cmdType == "e") {
-		int size = std::stoi(valueHex);
-		executeErase(lba, size);
-	}
-	else {
-		throw std::invalid_argument("Invalid command. Use 'R', 'W', or 'E'.");
-	}
+void Command::execute(const std::string& cmdTypeRaw, int lba, const std::string& valueHex) {
+    std::string cmdType = cmdTypeRaw;
+    std::transform(cmdType.begin(), cmdType.end(), cmdType.begin(), ::toupper);  // 대소문자 구분 없이 처리
+
+    if (cmdType == "W") {
+        if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0X") {
+            throw std::invalid_argument("Invalid hex format. Must be '0x' followed by 8 hex digits.");
+        }
+
+        std::string fullCmd = "W " + std::to_string(lba) + " " + valueHex;
+        buffer->addCommandToBuffer(CommandValue(fullCmd));
+    }
+    else if (cmdType == "E") {
+        int size = std::stoi(valueHex);
+        if (size < 1 || size > 10) {
+            throw std::invalid_argument("Invalid erase size. Must be between 1 and 10.");
+        }
+
+        std::string fullCmd = "E " + std::to_string(lba) + " " + std::to_string(size);
+        buffer->addCommandToBuffer(CommandValue(fullCmd));
+    }
+    else if (cmdType == "F") {
+        buffer->flush();
+    }
+    else if (cmdType == "R") {
+        uint32_t value = ssd->readLBA(lba);
+
+        std::ostringstream oss;
+        oss << "0x" << std::setfill('0') << std::setw(8)
+            << std::hex << std::uppercase << value;
+
+        outputFile->saveToFile(oss.str());
+    }
+    else {
+        throw std::invalid_argument("Invalid command. Use 'R', 'W', 'E', or 'F'.");
+    }
 }
-
-
-void Command::executeWrite(int lba, const std::string& valueHex) {
-	if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0x")
-		throw std::invalid_argument("Invalid hex format. Must be '0x' followed by 8 hex digits.");
-
-	uint32_t value = std::stoul(valueHex, nullptr, 16);
-	ssd->writeLBA(lba, value);
-}
-
-void Command::executeRead(int lba) {
-	uint32_t value = ssd->readLBA(lba);
-	std::ostringstream oss;
-	oss << "0x" << std::setfill('0') << std::setw(8)
-		<< std::hex << std::uppercase << value;
-	outputFile->saveToFile(oss.str());
-}
-
-void Command::executeErase(int lba, int size) {
-	if (lba < 0 || size <= 0 || size > 10 || (lba + size) > 100) {
-		outputFile->saveToFile("ERROR");
-		return;
-	}
-
-	for (int i = 0; i < size; ++i) {
-		ssd->writeLBA(lba + i, 0x00000000);
-	}
-}
-

--- a/AClass_SSD/Command.h
+++ b/AClass_SSD/Command.h
@@ -3,19 +3,18 @@
 #include <string>
 #include "SSDControllerInterface.h"
 #include "FileTextIOInterface.h"
+#include "CommandBuffer.h"
 
 class Command {
-public:
-	Command(std::shared_ptr<SSDControllerInterface> ssdData,
-		std::shared_ptr<FileTextIOInterface> outputFile);
-
-	void execute(const std::string& cmdType, int lba, const std::string& valueHex = "");
-
 private:
-	void executeWrite(int lba, const std::string& valueHex);
-	void executeRead(int lba);
-	void executeErase(int lba, int size);
+    std::shared_ptr<SSDControllerInterface> ssd;
+    std::shared_ptr<FileTextIOInterface> outputFile;
+    std::shared_ptr<CommandBuffer> buffer;
 
-	std::shared_ptr<SSDControllerInterface> ssd;
-	std::shared_ptr<FileTextIOInterface> outputFile;
+public:
+    Command(std::shared_ptr<SSDControllerInterface> ssd,
+        std::shared_ptr<FileTextIOInterface> outputFile,
+        std::shared_ptr<CommandBuffer> buffer);
+
+    void execute(const std::string& cmdType, int lba, const std::string& valueHex = "");
 };


### PR DESCRIPTION
작업 내용
- Write(W), Erase(E) 명령을 즉시 실행하지 않고 CommandBuffer에 저장
- 최대 5개의 명령어를 버퍼에 보관한 후, Flush(F) 명령 시 일괄 처리
- Buffer가 가득 찬 경우 자동으로 Flush 수행
- Read(R) 명령은 기존과 같이 즉시 실행

변경된 주요 파일
- Command.h / Command.cpp : 명령어 입력 시 CommandBuffer 처리 추가
- CommandBuffer.* : 버퍼 로직 관리 (flush, 파일 생성, 버퍼 상태 유지 등)

테스트
- SSD.exe 실행 시 W/E 명령은 buffer 폴더에 저장됨
- F 명령어 입력 시 실제 nand 파일 반영 확인됨
- R 명령은 정상적으로 읽고 output 파일에 기록됨

기타
- 명령어는 대소문자 구분 없이 처리됨
- buffer 디렉토리 및 텍스트 파일 자동 관리됨
