### PR TITLE
[refactor] CommandBuffer 기능 통합 및 flush 실행 구현

### DIFF
--- a/AClass_SSD/Command.cpp
+++ b/AClass_SSD/Command.cpp
@@ -9,9 +9,12 @@ Command::Command(std::shared_ptr<SSDControllerInterface> ssd,
 	std::shared_ptr<CommandBuffer> buffer)
 	: ssd(ssd), outputFile(outputFile), buffer(buffer) {}
 
-void Command::execute(const std::string& cmdTypeRaw, int lba, const std::string& valueHex) {
+void Command::execute(const std::string& cmdTypeRaw, int lba, const std::string& valueHexRaw) {
 	std::string cmdType = cmdTypeRaw;
 	std::transform(cmdType.begin(), cmdType.end(), cmdType.begin(), ::toupper);
+
+	std::string valueHex = valueHexRaw;
+	std::transform(valueHex.begin(), valueHex.end(), valueHex.begin(), ::toupper);
 
 	if (cmdType == "W") {
 		if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0X") {

--- a/AClass_SSD/CommandBuffer.h
+++ b/AClass_SSD/CommandBuffer.h
@@ -6,6 +6,7 @@
 #include <exception>
 #include <iomanip>
 #include "FileTextIO.h"
+#include "SSDControllerInterface.h"
 
 class CommandValue {
 public:
@@ -89,12 +90,13 @@ private:
 	std::vector<CommandValue> buffer;
 	const int maxBufferSize = 5;
 	const std::string bufferDir = "./buffer";
+	std::shared_ptr<SSDControllerInterface> ssd;
 
 	void loadInitialFiles();
 	void createTxtFilesOnDestruction() const;
 
 public:
-	CommandBuffer();
+	CommandBuffer(std::shared_ptr<SSDControllerInterface> ssd);
 	~CommandBuffer();
 
 	void addCommandToBuffer(CommandValue command);

--- a/AClass_SSD/CommandTest.cpp
+++ b/AClass_SSD/CommandTest.cpp
@@ -10,48 +10,48 @@ using namespace ::testing;
 
 class MockSSDController : public SSDControllerInterface {
 public:
-    MockSSDController(std::shared_ptr<FileTextIOInterface> data = nullptr)
-        : SSDControllerInterface(std::move(data)) {}
+	MockSSDController(std::shared_ptr<FileTextIOInterface> data = nullptr)
+		: SSDControllerInterface(std::move(data)) {}
 
-    MOCK_METHOD(void, writeLBA, (int lba, uint32_t value), (override));
-    MOCK_METHOD(uint32_t, readLBA, (int lba), (override));
+	MOCK_METHOD(void, writeLBA, (int lba, uint32_t value), (override));
+	MOCK_METHOD(uint32_t, readLBA, (int lba), (override));
 };
 
 class MockDataInterface : public FileTextIOInterface {
 public:
-    MockDataInterface(std::string fileName = "")
-        : FileTextIOInterface(fileName) {}
+	MockDataInterface(std::string fileName = "")
+		: FileTextIOInterface(fileName) {}
 
-    MOCK_METHOD(std::string, loadFromFile, (), (override));
-    MOCK_METHOD(void, saveToFile, (std::string), (const, override));
+	MOCK_METHOD(std::string, loadFromFile, (), (override));
+	MOCK_METHOD(void, saveToFile, (std::string), (const, override));
 };
 
 class CommandTest : public Test {
 protected:
-    std::shared_ptr<MockSSDController> mockSSD;
-    std::shared_ptr<MockDataInterface> mockOutputFile;
-    std::shared_ptr<CommandBuffer> dummyBuffer;
-    std::unique_ptr<Command> command;
+	std::shared_ptr<MockSSDController> mockSSD;
+	std::shared_ptr<MockDataInterface> mockOutputFile;
+	std::shared_ptr<CommandBuffer> dummyBuffer;
+	std::unique_ptr<Command> command;
 
-    void SetUp() override {
-        auto dummyIO = std::make_shared<MockDataInterface>("test.txt");
-        mockSSD = std::make_shared<MockSSDController>(dummyIO);
-        mockOutputFile = std::make_shared<MockDataInterface>("output.txt");
-        dummyBuffer = std::make_shared<CommandBuffer>();
-        command = std::make_unique<Command>(mockSSD, mockOutputFile, dummyBuffer);
-    }
+	void SetUp() override {
+		auto dummyIO = std::make_shared<MockDataInterface>("test.txt");
+		mockSSD = std::make_shared<MockSSDController>(dummyIO);
+		mockOutputFile = std::make_shared<MockDataInterface>("output.txt");
+		dummyBuffer = std::make_shared<CommandBuffer>(mockSSD);
+		command = std::make_unique<Command>(mockSSD, mockOutputFile, dummyBuffer);
+	}
 };
 
 TEST_F(CommandTest, ExecuteReadCommand_SavesFormattedOutput) {
-    EXPECT_CALL(*mockSSD, readLBA(5)).WillOnce(Return(0x1234ABCD));
-    EXPECT_CALL(*mockOutputFile, saveToFile("0x1234ABCD")).Times(1);
-    command->execute("R", 5);
+	EXPECT_CALL(*mockSSD, readLBA(5)).WillOnce(Return(0x1234ABCD));
+	EXPECT_CALL(*mockOutputFile, saveToFile("0x1234ABCD")).Times(1);
+	command->execute("R", 5);
 }
 
 TEST_F(CommandTest, ExecuteInvalidCommand_ThrowsException) {
-    EXPECT_THROW(command->execute("Z", 1), std::invalid_argument);
+	EXPECT_THROW(command->execute("Z", 1), std::invalid_argument);
 }
 
 TEST_F(CommandTest, ExecuteWriteWithBadHexFormat_ThrowsException) {
-    EXPECT_THROW(command->execute("W", 2, "12345678"), std::invalid_argument);
+	EXPECT_THROW(command->execute("W", 2, "12345678"), std::invalid_argument);
 }

--- a/AClass_SSD/main.cpp
+++ b/AClass_SSD/main.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <memory>
+#include <algorithm>
 
 #include "FileTextIOInterface.h"
 #include "FileTextIO.h"
@@ -9,15 +10,18 @@
 #include "Command.h"
 
 int main(int argc, char* argv[]) {
-
 	std::string cmdType = argv[1];
+	std::transform(cmdType.begin(), cmdType.end(), cmdType.begin(), ::toupper);
+
 	int lba = argc > 2 ? std::stoi(argv[2]) : 0;
+
 	std::string value = (argc == 4) ? argv[3] : "";
+	std::transform(value.begin(), value.end(), value.begin(), ::toupper);
 
 	std::shared_ptr<FileTextIOInterface> nand = std::make_shared<FileTextIO>("ssd_nand.txt");
 	std::shared_ptr<FileTextIOInterface> output = std::make_shared<FileTextIO>("ssd_output.txt");
 	std::shared_ptr<SSDControllerInterface> ssd = std::make_shared<SSDController>(nand);
-	std::shared_ptr<CommandBuffer> buffer = std::make_shared<CommandBuffer>();
+	std::shared_ptr<CommandBuffer> buffer = std::make_shared<CommandBuffer>(ssd);
 
 	Command command(ssd, output, buffer);
 


### PR DESCRIPTION
CommandBuffer 클래스에 flush() 기능 구현 완료

WRITE, ERASE 명령어를 SSD에 실제로 적용

CommandBuffer 내부에서 중복 Write 제거, Erase 병합 최적화 로직 반영

flush 시 buffer/*.txt 파일 정리 방식 개선

Command.cpp에서 명령어 파싱 시 대소문자 구분 없이 처리 (toupper 적용)

Main 함수에서 모든 입력값 대문자 처리 및 유효성 검증 로직 유지

GTest 테스트 코드에서 CommandBuffer 생성자 인자 추가에 따른 대응