### PR TITLE
[feat] Fast Read 기능 구현 및 CommandBuffer flush 반영

### DIFF
--- a/AClass_SSD/Command.cpp
+++ b/AClass_SSD/Command.cpp
@@ -37,7 +37,13 @@ void Command::execute(const std::string& cmdTypeRaw, int lba, const std::string&
 		buffer->flush();
 	}
 	else if (cmdType == "R") {
-		uint32_t value = ssd->readLBA(lba);
+		uint32_t value;
+		if (buffer->getBufferedValueIfExists(lba, value)) {
+			// Fast Read
+		}
+		else {
+			value = ssd->readLBA(lba);
+		}
 
 		std::ostringstream oss;
 		oss << "0x" << std::setfill('0') << std::setw(8)

--- a/AClass_SSD/CommandBuffer.cpp
+++ b/AClass_SSD/CommandBuffer.cpp
@@ -148,3 +148,16 @@ void CommandBuffer::flush() {
 
 	buffer.clear();
 }
+bool CommandBuffer::getBufferedValueIfExists(int lba, uint32_t& outValue) const {
+	for (auto it = buffer.rbegin(); it != buffer.rend(); ++it) {
+		if (it->command == CommandValue::WRITE && it->LBA == lba) {
+			outValue = it->value;
+			return true;
+		}
+		else if (it->command == CommandValue::ERASE && lba >= it->LBA && lba < it->LBA + static_cast<int>(it->value)) {
+			outValue = 0x00000000;
+			return true;
+		}
+	}
+	return false;
+}

--- a/AClass_SSD/CommandBuffer.h
+++ b/AClass_SSD/CommandBuffer.h
@@ -102,4 +102,5 @@ public:
 	void addCommandToBuffer(CommandValue command);
 	void flush();
 	void printBuffer() const;
+	bool getBufferedValueIfExists(int lba, uint32_t& outValue) const;
 };


### PR DESCRIPTION
주요 변경 사항
- Fast Read 알고리즘 구현
  - READ 명령어 수행 시, Buffer에 존재하는 WRITE or ERASE 명령어 기반으로 값을 반환
  - 실제 NAND 접근을 줄여 성능 최적화 가능
- flush 기능 구현:
  - CommandBuffer에 쌓인 WRITE/ERASE 명령어를 실제 SSD에 반영
  - 명령어별 파일 리네이밍 처리 및 버퍼 초기화

테스트 시나리오
- `W 10 0xABCDABCD` → `E 10 2` → `W 11 0xABCDABCD` 이후 `R 10`, `R 11` 확인
- `R 10` → 0x00000000, `R 11` → 0xABCDABCD 출력 확인됨

기타
- CommandBuffer에 SSDControllerInterface 의존성 주입
- getBufferedValueIfExists() 구현으로 버퍼 확인 기능 추