### PR TITLE
Refactor/ssd/command buffer merge ignore

### DIFF
--- a/AClass_SSD/CommandBuffer.cpp
+++ b/AClass_SSD/CommandBuffer.cpp
@@ -87,12 +87,15 @@ void CommandBuffer::addCommandToBuffer(CommandValue command)
 }
 
 
-void CommandBuffer::printBuffer() const
+std::string CommandBuffer::printBuffer() const
 {
+	std::string result = "";
 	std::cout << "[Buffer Contents]\n";
 	for (const auto& command : buffer) {
-		std::cout << "- " << command.getCommandStr() << "\n";
+		std::cout << command.getCommandStr() << "\n";
+		result += command.getCommandStr() + "\n";
 	}
+	return result;
 }
 
 void CommandBuffer::loadInitialFiles() {

--- a/AClass_SSD/CommandBuffer.h
+++ b/AClass_SSD/CommandBuffer.h
@@ -110,6 +110,7 @@ public:
 
 	void addCommandToBuffer(CommandValue command);
 	void flush();
-	void printBuffer() const;
+
+	std::string printBuffer() const;
 	bool getBufferedValueIfExists(int lba, uint32_t& outValue) const;
 };

--- a/AClass_SSD/CommandBuffer.h
+++ b/AClass_SSD/CommandBuffer.h
@@ -10,30 +10,39 @@
 
 class CommandValue {
 public:
+	static const int NULL_COMMAND = 0;
 	static const int WRITE = 1;
 	static const int READ = 2;
 	static const int ERASE = 3;
 
 	int command;
+
+	static const int MAX_NUM_LBA = 100;
+
 	int LBA;
 	uint32_t value;
 
 	CommandValue(const std::string& input) {
 		setCommand(input);
 	}
-	CommandValue(char chCommad, int LBA, uint32_t value) {
-		if (chCommad == 'W') {
+	CommandValue(char chCommand, int LBA, uint32_t value) {
+		if (chCommand == 'W') {
 			command = WRITE;
 		}
-		else if (chCommad == 'E') {
+		else if (chCommand == 'E') {
 			command = ERASE;
 		}
-		else if (chCommad == 'R') {
+		else if (chCommand == 'R') {
 			command = READ;
 		}
 		else {
 			command = 0;
 		}
+		this->LBA = LBA;
+		this->value = value;
+	}
+	CommandValue(int command, int LBA, uint32_t value) {
+		this->command = command;
 		this->LBA = LBA;
 		this->value = value;
 	}


### PR DESCRIPTION
addCommandToBuffer 함수 수정하였습니다
- 기존 로직으로는 코너 케이스에서 실패하는 경우가 있어서 버퍼를 잡아서 체크하는 방식으로 수정하였습니다
- printBuffer 함수 테스트 작성을 위하여 string 리턴하도록 수정하였습니다.