### PR TITLE
[refactor] Command, main에 디자인 패턴 적용

### DIFF
--- a/AClass_SSD/Command.cpp
+++ b/AClass_SSD/Command.cpp
@@ -19,13 +19,16 @@ void Command::execute(const std::string& cmdTypeRaw, int lba, const std::string&
 	if (cmdType == "W") {
 		if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0X")
 			throw std::invalid_argument("Invalid hex format. Must be '0x' followed by 8 hex digits.");
-		buffer->addCommandToBuffer(CommandValue("W " + std::to_string(lba) + " " + valueHex));
+
+		uint32_t value = std::stoul(valueHex, nullptr, 16);
+		buffer->addCommandToBuffer(CommandValue('W', lba, value));
 	}
 	else if (cmdType == "E") {
 		int size = std::stoi(valueHex);
 		if (size < 1 || size > 10)
 			throw std::invalid_argument("Invalid erase size. Must be between 1 and 10.");
-		buffer->addCommandToBuffer(CommandValue("E " + std::to_string(lba) + " " + std::to_string(size)));
+
+		buffer->addCommandToBuffer(CommandValue('E', lba, size));
 	}
 	else if (cmdType == "F") {
 		buffer->flush();

--- a/AClass_SSD/Command.cpp
+++ b/AClass_SSD/Command.cpp
@@ -17,33 +17,23 @@ void Command::execute(const std::string& cmdTypeRaw, int lba, const std::string&
 	std::transform(valueHex.begin(), valueHex.end(), valueHex.begin(), ::toupper);
 
 	if (cmdType == "W") {
-		if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0X") {
+		if (valueHex.length() != 10 || valueHex.substr(0, 2) != "0X")
 			throw std::invalid_argument("Invalid hex format. Must be '0x' followed by 8 hex digits.");
-		}
-
-		std::string fullCmd = "W " + std::to_string(lba) + " " + valueHex;
-		buffer->addCommandToBuffer(CommandValue(fullCmd));
+		buffer->addCommandToBuffer(CommandValue("W " + std::to_string(lba) + " " + valueHex));
 	}
 	else if (cmdType == "E") {
 		int size = std::stoi(valueHex);
-		if (size < 1 || size > 10) {
+		if (size < 1 || size > 10)
 			throw std::invalid_argument("Invalid erase size. Must be between 1 and 10.");
-		}
-
-		std::string fullCmd = "E " + std::to_string(lba) + " " + std::to_string(size);
-		buffer->addCommandToBuffer(CommandValue(fullCmd));
+		buffer->addCommandToBuffer(CommandValue("E " + std::to_string(lba) + " " + std::to_string(size)));
 	}
 	else if (cmdType == "F") {
 		buffer->flush();
 	}
 	else if (cmdType == "R") {
 		uint32_t value;
-		if (buffer->getBufferedValueIfExists(lba, value)) {
-			// Fast Read
-		}
-		else {
+		if (buffer->getBufferedValueIfExists(lba, value) == false)
 			value = ssd->readLBA(lba);
-		}
 
 		std::ostringstream oss;
 		oss << "0x" << std::setfill('0') << std::setw(8)

--- a/AClass_SSD/Command.h
+++ b/AClass_SSD/Command.h
@@ -5,7 +5,13 @@
 #include "FileTextIOInterface.h"
 #include "CommandBuffer.h"
 
-class Command {
+class ICommandExecutor {
+public:
+	virtual ~ICommandExecutor() = default;
+	virtual void execute(const std::string& cmdType, int lba, const std::string& valueHex = "") = 0;
+};
+
+class Command : public ICommandExecutor {
 private:
 	std::shared_ptr<SSDControllerInterface> ssd;
 	std::shared_ptr<FileTextIOInterface> outputFile;
@@ -16,5 +22,5 @@ public:
 		std::shared_ptr<FileTextIOInterface> outputFile,
 		std::shared_ptr<CommandBuffer> buffer);
 
-	void execute(const std::string& cmdType, int lba, const std::string& valueHex = "");
+	void execute(const std::string& cmdType, int lba, const std::string& valueHex = "") override;
 };


### PR DESCRIPTION
- 기존 Command 클래스에 ICommandExecutor 인터페이스를 도입하여 실행 로직을 추상화하였습니다.
- main.cpp에서 직접 Command 객체를 생성하던 구조를 추상 인터페이스 기반 구조로 변경했습니다.
- 새로운 createCommandExecutor() 팩토리 함수로 실행 전략을 생성하여 유연성과 테스트 편의성 향상.
- main은 ICommandExecutor에 의존함으로써 Command 클래스와의 결합도를 낮춤.
- 향후 명령어 실행 로직 확장 시 OCP 원칙(Open/Closed Principle)을 준수할 수 있도록 구조 개선.

적용한 디자인 패턴: Strategy Pattern + Interface Abstraction