### PR TITLE
Refact/ssd/command buffer

### DIFF
--- a/AClass_SSD/CommandBuffer.cpp
+++ b/AClass_SSD/CommandBuffer.cpp
@@ -79,12 +79,20 @@ void CommandBuffer::removeOverwrittenSingleErase()
 		if (buf->command == CommandValue::WRITE) {
 			checkBuffer[buf->LBA] = CommandValue::WRITE;
 		}
-		else if (buf->command == CommandValue::ERASE && buf->value == 1) {
-			if (checkBuffer[buf->LBA] == CommandValue::WRITE) {
+		else if (buf->command == CommandValue::ERASE ) {
+			if (buf->value == 1 && checkBuffer[buf->LBA] == CommandValue::WRITE) {
 				buf = std::vector<CommandValue>::reverse_iterator(buffer.erase((buf + 1).base()));
 				continue;
 			}
+			else if (checkBuffer[buf->LBA] == CommandValue::WRITE) {
+				buf->LBA = buf->LBA + 1;
+				buf->value -= 1;
+			}
+			else if (checkBuffer[buf->LBA +buf->value -1] == CommandValue::WRITE) {
+				buf->value -= 1;
+			}
 		}
+
 		buf++;
 	}
 }

--- a/AClass_SSD/CommandBuffer.h
+++ b/AClass_SSD/CommandBuffer.h
@@ -105,13 +105,15 @@ private:
 	void loadInitialFiles();
 	void createTxtFilesOnDestruction() const;
 
+	void removeOverwrittenSingleErase();
 	void mergeEraseRange(std::vector<int>& checkBuffer);
-	void removeOverlappingEraseCommands(CommandValue& command, std::vector<int>& checkBuffer);
+	void setCheckBufferOnEraseCommands(std::vector<int>& checkBuffer);
 	void removeOverlappingWriteCommands(std::vector<int>& checkBuffer);
 	std::vector<int> initCheckBufferWith(CommandValue& command);
 
 	void renameBufferFilesToEmpty();
 	void flushCommandsToSSD();
+
 
 public:
 	CommandBuffer(std::shared_ptr<SSDControllerInterface> ssd);
@@ -120,8 +122,6 @@ public:
 	void addCommandToBuffer(CommandValue command);
 
 	void flush();
-
-
 
 	std::string printBuffer() const;
 	bool getBufferedValueIfExists(int lba, uint32_t& outValue) const;

--- a/AClass_SSD/CommandBufferTest.cpp
+++ b/AClass_SSD/CommandBufferTest.cpp
@@ -25,6 +25,9 @@ public:
 		mockSSD = std::make_shared<MockSSDController>();
 	}
 	void removeFilesAt(std::string dirPath) {
+		if (!fs::exists(dirPath)) {
+			return;
+		}
 		for (const auto& entry : fs::directory_iterator(dirPath)) {
 			if (entry.is_regular_file()) {
 				fs::remove(entry.path());
@@ -41,9 +44,7 @@ TEST_F(CommandBufferTest, tc) {
 	CommandValue command(strCommand);
 
 	buffer.printBuffer();
-
 	buffer.addCommandToBuffer(command);
-
 	EXPECT_EQ(buffer.printBuffer(), "W 20 0xABCDABCD\n");
 }
 

--- a/AClass_SSD/CommandBufferTest.cpp
+++ b/AClass_SSD/CommandBufferTest.cpp
@@ -398,6 +398,23 @@ TEST_F(CommandBufferTest, tc17) {
 	command.setCommand(strCommand);
 	buffer.addCommandToBuffer(command);
 	EXPECT_EQ(buffer.printBuffer(), "E 89 10\nE 29 10\nW 99 0x11112222\n");
+
+	strCommand = "W 32 0xFFFFAAAA";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 89 10\nE 29 10\nW 99 0x11112222\nW 32 0xFFFFAAAA\n");
+
+	strCommand = "E 39 10";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 89 10\nE 39 10\nE 29 10\nW 99 0x11112222\nW 32 0xFFFFAAAA\n");
+
+	uint32_t result;
+	buffer.getBufferedValueIfExists(29, result);
+	EXPECT_EQ(result, 0x00000000);
+
+	buffer.getBufferedValueIfExists(99, result);
+	EXPECT_EQ(result, 0x11112222);
 }
 
 TEST_F(CommandBufferTest, tc18) {

--- a/AClass_SSD/CommandBufferTest.cpp
+++ b/AClass_SSD/CommandBufferTest.cpp
@@ -392,7 +392,8 @@ TEST_F(CommandBufferTest, tc17) {
 	strCommand = "W 99 0x11112222";
 	command.setCommand(strCommand);
 	buffer.addCommandToBuffer(command);
-	EXPECT_EQ(buffer.printBuffer(), "E 98 2\nE 29 10\nW 99 0x11112222\n");
+	//EXPECT_EQ(buffer.printBuffer(), "E 98 2\nE 29 10\nW 99 0x11112222\n");
+	EXPECT_EQ(buffer.printBuffer(), "E 98 1\nE 29 10\nW 99 0x11112222\n");
 
 	strCommand = "E 89 10";
 	command.setCommand(strCommand);
@@ -431,4 +432,25 @@ TEST_F(CommandBufferTest, tc18) {
 	command.setCommand(strCommand);
 	buffer.addCommandToBuffer(command);
 	EXPECT_EQ(buffer.printBuffer(), "W 99 0x11112222\n");
+}
+
+TEST_F(CommandBufferTest, tc19) {
+	removeFilesAt("./buffer");
+	CommandBuffer buffer(mockSSD);
+	std::string strCommand = "W 1 0xFFFF1111";
+	CommandValue command(strCommand);
+
+	buffer.printBuffer();
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "W 1 0xFFFF1111\n");
+
+	strCommand = "E 10 2";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 10 2\nW 1 0xFFFF1111\n");
+
+	strCommand = "W 10 0xFFFF1111";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 11 1\nW 1 0xFFFF1111\nW 10 0xFFFF1111\n");
 }

--- a/AClass_SSD/CommandBufferTest.cpp
+++ b/AClass_SSD/CommandBufferTest.cpp
@@ -313,3 +313,105 @@ TEST_F(CommandBufferTest, tc14) {
 	buffer.addCommandToBuffer(command);
 	EXPECT_EQ(buffer.printBuffer(), "E 95 5\n");
 }
+
+TEST_F(CommandBufferTest, tc15) {
+	removeFilesAt("./buffer");
+	CommandBuffer buffer(mockSSD);
+	std::string strCommand = "E 89 5";
+	CommandValue command(strCommand);
+
+	buffer.printBuffer();
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 89 5\n");
+
+	strCommand = "E 92 8";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 99 1\nE 89 10\n");
+}
+
+TEST_F(CommandBufferTest, tc16) {
+	removeFilesAt("./buffer");
+	CommandBuffer buffer(mockSSD);
+	std::string strCommand = "E 20 9";
+	CommandValue command(strCommand);
+
+	buffer.printBuffer();
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 20 9\n");
+
+	strCommand = "E 29 9";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 30 8\nE 20 10\n");
+
+	strCommand = "E 38 10";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 40 8\nE 30 10\nE 20 10\n");
+
+	strCommand = "E 46 10";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 50 6\nE 40 10\nE 30 10\nE 20 10\n");
+
+	strCommand = "E 56 9";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 60 5\nE 50 10\nE 40 10\nE 30 10\nE 20 10\n");
+
+	EXPECT_CALL(*mockSSD, writeLBA(Ge(20), CommandValue::EMPTY_VALUE))
+		.Times(45);
+	strCommand = "E 63 8";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	//EXPECT_EQ(buffer.printBuffer(), "E 60 5\nE 50 10\nE 40 10\nE 30 10\nE 20 10\n");
+	EXPECT_EQ(buffer.printBuffer(), "E 63 8\n");
+}
+
+TEST_F(CommandBufferTest, tc17) {
+	removeFilesAt("./buffer");
+	CommandBuffer buffer(mockSSD);
+	std::string strCommand = "W 99 0x11112222";
+	CommandValue command(strCommand);
+
+	buffer.printBuffer();
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "W 99 0x11112222\n");
+
+	strCommand = "E 29 10";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 29 10\nW 99 0x11112222\n");
+
+	strCommand = "E 98 2";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 98 2\nE 29 10\n");
+
+	strCommand = "W 99 0x11112222";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 98 2\nE 29 10\nW 99 0x11112222\n");
+
+	strCommand = "E 89 10";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 89 10\nE 29 10\nW 99 0x11112222\n");
+}
+
+TEST_F(CommandBufferTest, tc18) {
+	removeFilesAt("./buffer");
+	CommandBuffer buffer(mockSSD);
+	std::string strCommand = "E 99 1";
+	CommandValue command(strCommand);
+
+	buffer.printBuffer();
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "E 99 1\n");
+
+	strCommand = "W 99 0x11112222";
+	command.setCommand(strCommand);
+	buffer.addCommandToBuffer(command);
+	EXPECT_EQ(buffer.printBuffer(), "W 99 0x11112222\n");
+}


### PR DESCRIPTION
E 1 2
W 1 0xFFFF1111
W 2 0xFFFF2222
이면
W 1 0xFFFF1111
W 2 0xFFFF2222
이 되도록 수정한 내용 입니다.

즉, 앞서 있는 E 값이 모두 W로 덮히는 경우 해당 커맨드는 없어져야 합니다.

그 외에 함수명 리팩토링하고, 테스트 케이스 추가하였습니다.