### PR TITLE
[bugfix] error log출력 잘못

### DIFF
--- a/Interface/ITestShell.cpp
+++ b/Interface/ITestShell.cpp
@@ -142,7 +142,7 @@ bool ITestShell::isWriteCommandValid(const vector<string> commandToken) {
 	if ((commandToken.size() != TOKEN_WRITE_NUM) ||
 		(!isLBAValid(commandToken[TOKEN_WRITE_LBA])) ||
 		(!isWriteDataValid(commandToken[TOKEN_WRITE_DATA]))) {
-		ADD_LOG("ITestShell::isReadCommandValid", "ERROR");
+		ADD_LOG("ITestShell::isWriteCommandValid", "ERROR");
 
 		return false;
 	}


### PR DESCRIPTION
isWriteCommandValid함수에서 error시
isWriteCommandValid error를 출력해야하나
isReadCommandValid error를 출력하고있음