### PR TITLE
[fix] 잘못된 명령어 입력 시 런타임 에러 방지 및 ERROR 출력

### DIFF
--- a/AClass_SSD/main.cpp
+++ b/AClass_SSD/main.cpp
@@ -17,21 +17,38 @@ std::shared_ptr<ICommandExecutor> createCommandExecutor(
 }
 
 int main(int argc, char* argv[]) {
-	std::string cmdType = argv[1];
-	std::transform(cmdType.begin(), cmdType.end(), cmdType.begin(), ::toupper);
-
-	int lba = (argc > 2) ? std::stoi(argv[2]) : 0;
-	std::string value = (argc == 4) ? argv[3] : "";
-	std::transform(value.begin(), value.end(), value.begin(), ::toupper);
-
 	auto nand = std::make_shared<FileTextIO>("ssd_nand.txt");
 	auto output = std::make_shared<FileTextIO>("ssd_output.txt");
 	auto ssd = std::make_shared<SSDController>(nand);
 	auto buffer = std::make_shared<CommandBuffer>(ssd);
-
 	auto executor = createCommandExecutor(ssd, output, buffer);
 
 	try {
+		if (argc < 2) {
+			throw std::invalid_argument("비정상 입력입니다.");
+		}
+
+		std::string cmdType = argv[1];
+		std::transform(cmdType.begin(), cmdType.end(), cmdType.begin(), ::toupper);
+
+		int lba = 0;
+		std::string value = "";
+
+		if (cmdType == "W" || cmdType == "E" || cmdType == "R") {
+			if (argc < 3) {
+				throw std::invalid_argument("비정상 입력입니다.");
+			}
+			lba = std::stoi(argv[2]);
+		}
+
+		if (cmdType == "W" || cmdType == "E") {
+			if (argc < 4) {
+				throw std::invalid_argument("비정상 입력입니다.");
+			}
+			value = argv[3];
+			std::transform(value.begin(), value.end(), value.begin(), ::toupper);
+		}
+
 		executor->execute(cmdType, lba, value);
 	}
 	catch (const std::exception& e) {


### PR DESCRIPTION
- 명령어 포맷 검증 강화 (argc, stoi 예외 포함)
- 명령어 W, E, R 시 인자 개수 및 형식 체크 추가
- 예외 발생 시 ssd_output.txt에 "ERROR" 출력